### PR TITLE
spanish settings (initial language toggle implementation)

### DIFF
--- a/components/es/layout/SettingsTab.tsx
+++ b/components/es/layout/SettingsTab.tsx
@@ -8,7 +8,7 @@ interface SettingsTabProps {
 
 export const SettingsTab: React.FC<SettingsTabProps> = ({ onClose }) => {
   const tabRef = useRef<HTMLDivElement | null>(null);
-  const language = "en";
+  const language = "es";
 
   // Close if user clicks outside the tab
   useEffect(() => {

--- a/components/es/layout/header.tsx
+++ b/components/es/layout/header.tsx
@@ -5,16 +5,16 @@ import { useState } from "react"
 import  { PracticeTab } from "./PracticeTab"
 import { supabase } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
+import { SettingsTab } from "./SettingsTab"
 
 export function Header() {
-  const [showTab, setShowTab] = useState(false);
+  const [showPractice, setShowPractice] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const router = useRouter();
-  const handleToggle = () => {
-    setShowTab((prev) => !prev);
-  };
-  const handleClose = () => {
-    setShowTab(false);
-  };
+
+  // Toggle functions
+  const togglePractice = () => setShowPractice((prev) => !prev);
+  const toggleSettings = () => setShowSettings((prev) => !prev);
 
   const clearGoogleCookies = () => {
     // Clear Google OAuth cookies
@@ -58,11 +58,11 @@ export function Header() {
         <div className="relative">
             <Button
               className="bg-[#FF9147] text-white hover:bg-[#E67E33]"
-              onClick={handleToggle}
+              onClick={togglePractice}
             >
               Practicar
             </Button>
-            {showTab && <PracticeTab onClose={handleClose} />} {}
+            {showPractice && <PracticeTab onClose={togglePractice} />} {}
           </div>
           
           <Link href="/vocab">
@@ -70,9 +70,16 @@ export function Header() {
               Vocab
             </Button>
           </Link>
-          <Link href="/settings" className="mr-4">
-            <span className="text-sm hover:text-gray-600">Configuracion</span>
-          </Link>
+            {/* Settings Button */}
+            <div className="relative">
+              <button
+                className="w-10 h-10 flex items-center justify-center bg-gray-200 rounded-md hover:bg-gray-300"
+                onClick={toggleSettings}
+              >
+                <Image src="/gear_icon.png" alt="Settings" width={24} height={24} />
+              </button>
+              {showSettings && <SettingsTab onClose={() => setShowSettings(false)} />}
+            </div>
           <Link href="/">
             <span className="text-sm text-red-600 hover:text-red-700"onClick={handleLogout}>Cerrar sesión</span>
           </Link>

--- a/lang/translations.ts
+++ b/lang/translations.ts
@@ -1,0 +1,17 @@
+// translations.ts
+
+export const Settings_tr = {
+    en: {
+      title: "Settings",
+      options: "Settings Options:",
+      description: "⚙️ Settings.",
+      close: "Close",
+    },
+    es: {
+      title: "Configuraciones",
+      options: "Opciones de configuración:",
+      description: "⚙️ Configuraciones.",
+      close: "Cerrar",
+    },
+  };
+  


### PR DESCRIPTION
- spanish settings tab created
- trying out an early stage of the language toggle
- currently hard coded "en" and "es" language translations (text from each language found in lang/translations)
- eventual implementation, based off the preferred language "en" or "es" will be chosen. (for example if my preferred language is english "en" will be used throughout the site and english text will be used for all settings, definitions, etc.)